### PR TITLE
Use go template instead of manually replacing vars

### DIFF
--- a/genee-test.yml
+++ b/genee-test.yml
@@ -11,5 +11,5 @@ vars:
   - name: db_name
     value: genee
 commands:
-  - go mod init {{<service_name>}}
+  - go mod init {{.service_name}}
   - go mod tidy

--- a/genee.yml
+++ b/genee.yml
@@ -6,5 +6,5 @@ vars:
   - name: docker_registry
     value: pineappleworkshop
 commands:
-  - go mod init {{<service_name>}}
+  - go mod init {{.service_name}}
   - go mod tidy

--- a/models/config_model.go
+++ b/models/config_model.go
@@ -1,238 +1,29 @@
 package models
 
 import (
-	"bufio"
-	"errors"
-	"fmt"
-	"strings"
+	"bytes"
+	"text/template"
 )
 
 type Config struct {
-	Vars     []Var    `yaml:"vars"`
-	Commands []string `yaml:"commands"`
-}
-
-type Var struct {
-	Name  string `yaml:"name"`
-	Value string `yaml:"value"`
+	Vars     map[string]interface{} `yaml:"vars"`
+	Commands []string               `yaml:"commands"`
 }
 
 func (c *Config) SearchReplaceVars() error {
 	for i, command := range c.Commands {
-		count := c.countVars(command)
-		commandParsed, err := c.parseAndReplaceVar(command)
+		t, err := template.New("").Parse(command)
+		if err != nil {
+			return err
+		}
+		var commandParsed bytes.Buffer
+		err = t.Execute(&commandParsed, c.Vars)
 		if err != nil {
 			return err
 		}
 
-		for i := 0; i < count; i++ {
-			commandParsed, err = c.parseAndReplaceVar(commandParsed)
-			if err != nil {
-				return err
-			}
-		}
-		c.Commands[i] = commandParsed
+		c.Commands[i] = commandParsed.String()
 	}
 
 	return nil
-}
-
-func (c *Config) parseAndReplaceVar(command string) (string, error) {
-	data := bufio.NewScanner(strings.NewReader(command))
-	data.Split(bufio.ScanRunes)
-
-	begin1 := -1
-	begin2 := -1
-	begin3 := -1
-	end1 := -1
-	end2 := -1
-	end3 := -1
-
-	index := 0
-	for data.Scan() {
-		if data.Text() == "{" {
-			if begin1 == -1 {
-				begin1 = index
-				index++
-				continue
-			}
-		}
-		if begin1 != -1 {
-			if data.Text() == "{" {
-				if begin2 == -1 {
-					begin2 = index
-					index++
-					continue
-				}
-			}
-			if begin2 != -1 {
-				if data.Text() == "<" {
-					begin3 = index
-					index++
-					continue
-				}
-			}
-		}
-		if data.Text() == ">" {
-			if end1 == -1 {
-				end1 = index
-				index++
-				continue
-			}
-		}
-		if end1 != -1 {
-			if data.Text() == "}" {
-				if end2 == -1 {
-					end2 = index
-					index++
-					continue
-				}
-			}
-			if end2 != -1 {
-				if data.Text() == "}" {
-					end3 = index
-					index++
-					continue
-				}
-			}
-		}
-
-		if end3 != -1 {
-			break
-		}
-		index++
-	}
-
-	data = bufio.NewScanner(strings.NewReader(command))
-	data.Split(bufio.ScanRunes)
-	varName := ""
-	index = 0
-	for data.Scan() {
-		if index > begin3 {
-			if index < end1 {
-				varName = fmt.Sprintf("%s%s", varName, data.Text())
-			}
-		}
-		index++
-	}
-
-	data = bufio.NewScanner(strings.NewReader(command))
-	data.Split(bufio.ScanRunes)
-	commandParsed := ""
-	index = 0
-	for data.Scan() {
-		if index == begin1 {
-			varValue, err := findVarValue(varName, c)
-			if err != nil {
-				return "", err
-			}
-			commandParsed = fmt.Sprintf("%s%s", commandParsed, varValue)
-		}
-
-		if index >= begin1 {
-			if index <= end3 {
-				index++
-				continue
-			}
-		}
-
-		commandParsed = fmt.Sprintf("%s%s", commandParsed, data.Text())
-		index++
-	}
-	return commandParsed, nil
-}
-
-func findVarValue(varName string, c *Config) (string, error) {
-	var varValue string
-	for _, xvar := range c.Vars {
-		if xvar.Name == varName {
-			varValue = xvar.Value
-		}
-	}
-
-	if varValue == "" {
-		return "", errors.New(fmt.Sprintf("`%s` was not found in config", varName))
-	}
-	return varValue, nil
-}
-
-func (c *Config) countVars(command string) int {
-	count := 0
-
-	data := bufio.NewScanner(strings.NewReader(command))
-	data.Split(bufio.ScanRunes)
-
-	begin1 := -1
-	begin2 := -1
-	begin3 := -1
-	end1 := -1
-	end2 := -1
-	end3 := -1
-
-	index := 0
-	for data.Scan() {
-		if data.Text() == "{" {
-			if begin1 == -1 {
-				begin1 = index
-				index++
-				continue
-			}
-		}
-		if begin1 != -1 {
-			if data.Text() == "{" {
-				if begin2 == -1 {
-					begin2 = index
-					index++
-					continue
-				}
-			}
-			if begin2 != -1 {
-				if data.Text() == "<" {
-					begin3 = index
-					index++
-					continue
-				}
-			}
-		}
-		if data.Text() == ">" {
-			if end1 == -1 {
-				end1 = index
-				index++
-				continue
-			}
-		}
-		if end1 != -1 {
-			if data.Text() == "}" {
-				if end2 == -1 {
-					end2 = index
-					index++
-					continue
-				}
-			}
-			if end2 != -1 {
-				if data.Text() == "}" {
-					end3 = index
-					index++
-					continue
-				}
-			}
-		}
-
-		if end3 != -1 {
-			begin1 = -1
-			begin2 = -1
-			begin3 = -1
-			end1 = -1
-			end2 = -1
-			end3 = -1
-			count++
-		}
-		index++
-	}
-
-	if begin3 == -1 {
-		return count
-	}
-
-	return count
 }

--- a/models/file_model.go
+++ b/models/file_model.go
@@ -1,242 +1,28 @@
 package models
 
 import (
-	"bufio"
-	"fmt"
-	"strings"
+	"bytes"
+	"text/template"
 )
 
 type File struct {
 	Template    string
 	Destination string
-	FileStr string
+	FileStr     string
 }
 
 func (f *File) SearchReplaceVars(c *Config) error {
-	count := f.countVars()
-	fileParsed, err := f.parseAndReplaceVar(c, f.FileStr)
+	t, err := template.New("").Parse(f.FileStr)
+	if err != nil {
+		return err
+	}
+	var fileParsed bytes.Buffer
+	err = t.Execute(&fileParsed, c.Vars)
 	if err != nil {
 		return err
 	}
 
-	for i := 0; i < count; i++ {
-		fileParsed, err = f.parseAndReplaceVar(c, fileParsed)
-		if err != nil {
-			return err
-		}
-	}
-	f.FileStr = fileParsed
+	f.FileStr = fileParsed.String()
 
 	return nil
-}
-
-func (f *File) parseAndReplaceVar(c *Config, fileStr string) (string, error) {
-	data := bufio.NewScanner(strings.NewReader(fileStr))
-	data.Split(bufio.ScanRunes)
-
-	begin1 := -1
-	begin2 := -1
-	begin3 := -1
-	end1 := -1
-	end2 := -1
-	end3 := -1
-
-	index := 0
-	for data.Scan() {
-		if data.Text() == "{" {
-			if begin1 == -1 {
-				begin1 = index
-				index++
-				continue
-			}
-		}
-		if begin1 != -1 {
-			if data.Text() == "{" {
-				if begin2 == -1 {
-					begin2 = index
-					index++
-					continue
-				}
-			}
-			if begin2 != -1 {
-				if data.Text() == "<" {
-					begin3 = index
-					index++
-					continue
-				}
-			}
-		}
-		if data.Text() == ">" {
-			if end1 == -1 {
-				end1 = index
-				index++
-				continue
-			}
-		}
-		if end1 != -1 {
-			if data.Text() == "}" {
-				if end2 == -1 {
-					end2 = index
-					index++
-					continue
-				}
-			}
-			if end2 != -1 {
-				if data.Text() == "}" {
-					end3 = index
-					index++
-					continue
-				}
-			}
-		}
-
-		if begin1 != begin2-1 {
-			begin1 = -1
-			begin2 = -1
-			begin3 = -1
-			end1 = -1
-			end2 = -1
-			end3 = -1
-		}
-
-		if end3 != -1 {
-			break
-		}
-		index++
-	}
-
-	data = bufio.NewScanner(strings.NewReader(fileStr))
-	data.Split(bufio.ScanRunes)
-	varName := ""
-	index = 0
-	for data.Scan() {
-		if index > begin3 {
-			if index < end1 {
-				varName = fmt.Sprintf("%s%s", varName, data.Text())
-			}
-		}
-		index++
-	}
-
-	data = bufio.NewScanner(strings.NewReader(fileStr))
-	data.Split(bufio.ScanRunes)
-	commandParsed := ""
-	index = 0
-	for data.Scan() {
-		if index == begin1 {
-			//varValue, err := findVarValue(varName, c)
-			//if err != nil {
-			//	return "", err
-			//}
-			//commandParsed = fmt.Sprintf("%s%s", commandParsed, varValue)
-			if varName != "" {
-				varValue, err := findVarValue(varName, c)
-				if err != nil {
-					return "", err
-				}
-				commandParsed = fmt.Sprintf("%s%s", commandParsed, varValue)
-			}
-		}
-
-		if index >= begin1 {
-			if index <= end3 {
-				index++
-				continue
-			}
-		}
-
-		commandParsed = fmt.Sprintf("%s%s", commandParsed, data.Text())
-		index++
-	}
-	return commandParsed, nil
-}
-
-func (f *File) countVars() int {
-	count := 0
-
-	data := bufio.NewScanner(strings.NewReader(f.FileStr))
-	data.Split(bufio.ScanRunes)
-
-	begin1 := -1
-	begin2 := -1
-	begin3 := -1
-	end1 := -1
-	end2 := -1
-	end3 := -1
-
-	index := 0
-	for data.Scan() {
-		if data.Text() == "{" {
-			if begin1 == -1 {
-				begin1 = index
-				index++
-				continue
-			}
-		}
-		if begin1 != -1 {
-			if data.Text() == "{" {
-				if begin2 == -1 {
-					begin2 = index
-					index++
-					continue
-				}
-			}
-			if begin2 != -1 {
-				if data.Text() == "<" {
-					begin3 = index
-					index++
-					continue
-				}
-			}
-		}
-		if data.Text() == ">" {
-			if end1 == -1 {
-				end1 = index
-				index++
-				continue
-			}
-		}
-		if end1 != -1 {
-			if data.Text() == "}" {
-				if end2 == -1 {
-					end2 = index
-					index++
-					continue
-				}
-			}
-			if end2 != -1 {
-				if data.Text() == "}" {
-					end3 = index
-					index++
-					continue
-				}
-			}
-		}
-
-		if begin1 != begin2-1 {
-			begin1 = -1
-			begin2 = -1
-			begin3 = -1
-			end1 = -1
-			end2 = -1
-			end3 = -1
-		}
-
-		if end3 != -1 {
-			begin1 = -1
-			begin2 = -1
-			begin3 = -1
-			end1 = -1
-			end2 = -1
-			end3 = -1
-			count++
-		}
-		index++
-	}
-
-	if begin3 == -1 {
-		return count
-	}
-
-	return count
 }

--- a/template/services/model_temp
+++ b/template/services/model_temp
@@ -1,14 +1,14 @@
 package stores
 
 const (
-	DB_NAME = "{{<db_name>}}"
+	DB_NAME = "{{.db_name}}"
 )
 
 var (
 	MONGOHOSTS_WORKSTATION = []string{"localhost:27017"}
 	MONGOHOSTS_CLUSTER     = []string{
-		"{{<db_name>}}-mongodb-replicaset-0",
-		"{{<db_name>}}-mongodb-replicaset-1",
-		"{{<db_name>}}-mongodb-replicaset-2",
+		"{{.db_name}}-mongodb-replicaset-0",
+		"{{.db_name}}-mongodb-replicaset-1",
+		"{{.db_name}}-mongodb-replicaset-2",
 	}
 )


### PR DESCRIPTION
### Summary

I noticed that the vars replacement was being done manually and even though it was doing its job, those parsing methods were really complex (respect for writing that code). Go has [text templates](https://golang.org/pkg/text/template/) that allows you to do this exact thing and to do so we just needed to change a small thing:
1. Use the template syntax for vars `{{.var}}` instead of the current `{{<var>}}`
2. Change vars to be a yaml map instead of an array

You can find both changes on this PR https://github.com/pineappleworkshop/pw-go-template/pull/7, and because of that the changes made on this PR depends on those to work.

**NOTE:** Ideally, I would like to have tests in place before merging this. But on the meantime what I did was to run genee before and after the changes and the compare the generated projects to make sure they output is the same.