### PR TITLE
Add flag to use repo instead of local template folder

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -72,6 +72,7 @@ work, the expected flags are:
 | -c, --config string      |      Sets the configuration file to be used during generation      |
 | -d, --destination string | Sets the destination directory where the resulting project will be |
 | -t, --template string    |  Sets the template directory in which to generate a project from   |
+| -r, --repo string        |  Sets the repository link in which to generate a project from      |
 
 
 You can also use "genee [command] --help" for more information about a command.
@@ -85,29 +86,37 @@ The project called `pw-go-template` (https://github.com/pineappleworkshop/pw-go-
 provides use a Go project scaffold with integration to MongoDB
 and the initial configuration to deploy your code in Kubernetes.
 
-First thing that needs to be done is cloning `pw-go-template`
-project into your projects/working directory
+Yoo don't need to clone `pw-go-template` project into your projects/working directory,
+but if you want, here's the command to do it:
 ```bash
 cd ~/Projects
 git clone git@github.com:pineappleworkshop/pw-go-template.git
 ```
 
 Then, copy in your projects/working the `genee-test.yml` file that
-is into the `pw-go-template` project.
-The `genee-test.yml` file has all the basic initial configuration file with all the
-variables and values needed by `genee` to generate the service.
+is into the `pw-go-template` project. If you didn't clone, pull a copy
+directly from github.
 ```bash
 cp pw-go-template/genee-test.yml .
 mv genee-test.yml genee.yml
 ```
 
+The `genee-test.yml` file has all the basic initial configuration file with all the
+variables and values needed by `genee` to generate the service.
 Edit the `genee.yml` and set the values for each of the variables
 declared in there.
 
 In the following line replace `SERVICE_NAME` with the value set
 on the `service_name` variable in `genee.yml`.
+
+If you cloned the repo locally:
 ```bash
 genee project -t ./pw-go-template -d SERVICE_NAME -c ./genee.yml
+```
+
+If you didn't clone:
+```bash
+genee project -r git@github.com:pineappleworkshop/pw-go-template.git -d SERVICE_NAME -c ./genee.yml
 ```
 
 Finally, go to the terminal, paste the line above (once you have replace

--- a/cmd/const.go
+++ b/cmd/const.go
@@ -14,6 +14,10 @@ const (
 	CMD_PROJECT_TEMPLATE_SHORT = "t"
 	CMD_PROJECT_TEMPLATE_USAGE = "Sets the template directory in which to generate a project from"
 
+	CMD_PROJECT_REPO_LONG  = "repo"
+	CMD_PROJECT_REPO_SHORT = "r"
+	CMD_PROJECT_REPO_USAGE = "Sets the repository link in which to generate a project from"
+
 	CMD_PROJECT_DESTINATION_LONG  = "destination"
 	CMD_PROJECT_DESTINATION_SHORT = "d"
 	CMD_PROJECT_DESTINATION_USAGE = "Sets the destination directory where the resulting project will be located"

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -2,10 +2,17 @@ package cmd
 
 import (
 	"fmt"
+	"genee/services"
 	"os"
 )
 
 func errExit(msg interface{}) {
+	fmt.Println("Error:", msg)
+	os.Exit(1)
+}
+
+func errExitClean(msg interface{}, destination string) {
+	services.DeleteRoot(destination)
 	fmt.Println("Error:", msg)
 	os.Exit(1)
 }

--- a/services/commander.go
+++ b/services/commander.go
@@ -7,17 +7,23 @@ import (
 
 func RunCommands(destination string, commands []string) error {
 	for _, command := range commands {
-		fmt.Println(fmt.Sprintf("Running: %s", command))
 		commandParsed := fmt.Sprintf("cd %s && %s", destination, command)
-		cmd := exec.Command("bash", "-c", commandParsed)
-		stdout, err := cmd.CombinedOutput()
-		// _, err := cmd.CombinedOutput()
+		err := RunCommand(commandParsed)
 		if err != nil {
-			fmt.Println(fmt.Sprint(err) + ": " + string(stdout))
 			return err
 		}
+	}
 
-		// fmt.Println(string(stdout))
+	return nil
+}
+
+func RunCommand(command string) error {
+	fmt.Println(fmt.Sprintf("Running: %s", command))
+	cmd := exec.Command("bash", "-c", command)
+	stdout, err := cmd.CombinedOutput()
+	if err != nil {
+		fmt.Println(fmt.Sprint(err) + ": " + string(stdout))
+		return err
 	}
 
 	return nil

--- a/services/generator.go
+++ b/services/generator.go
@@ -100,3 +100,11 @@ func GenerateFiles(c *models.Config, template, destination string, filePaths []s
 
 	return nil
 }
+
+func DeleteRoot(path string) error {
+	if err := os.RemoveAll(path); err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
### Summary

This PR adds a new flag to the `project` command that lets you use a remote GitHub repo instead of needing to manually clone the repo to your local machine. This adds 2 benefits:
1. Since it's gonna clone the repo automatically, it's always gonna pull the latest version.
2. You don't need to keep unnecessary clones on your machine.